### PR TITLE
Add Phaser block placement example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# test
+# Simple Phaser Terraria-like Game
+
+This is a minimal example of a game built with [Phaser 3](https://phaser.io/). It demonstrates a very basic terrain-building mechanic with a simple inventory.
+
+## Features
+
+- Click to place blocks on a grid.
+- Press **Q** to cycle through block types.
+- Inventory shows the selected block.
+
+## Setup
+
+No build steps are required. Open `index.html` in a modern web browser. The project loads Phaser from a CDN.
+
+## Limitations
+
+This project is only a starting point and not a full Terraria clone. It shows how block placement and inventory selection can work in Phaser.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>Simple Terraria Style Game</title>
+  <style>
+    body { margin: 0; padding: 0; }
+    canvas { display: block; margin: 0 auto; }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.js"></script>
+</head>
+<body>
+  <script src="src/main.js"></script>
+</body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,89 @@
+class Inventory {
+  constructor(scene) {
+    this.scene = scene;
+    // simple inventory with 3 types of blocks
+    this.blocks = [0, 1, 2];
+    this.current = 0;
+  }
+  next() {
+    this.current = (this.current + 1) % this.blocks.length;
+  }
+  get type() {
+    return this.blocks[this.current];
+  }
+}
+
+class GameScene extends Phaser.Scene {
+  constructor() {
+    super('GameScene');
+  }
+
+  preload() {
+    // placeholder colors for blocks
+  }
+
+  create() {
+    this.inventory = new Inventory(this);
+    this.blockSize = 32;
+    this.gridWidth = 20;
+    this.gridHeight = 15;
+    this.grid = [];
+    for (let y = 0; y < this.gridHeight; y++) {
+      this.grid[y] = [];
+      for (let x = 0; x < this.gridWidth; x++) {
+        this.grid[y][x] = -1; // empty
+      }
+    }
+    this.graphics = this.add.graphics();
+    this.input.on('pointerdown', this.placeBlock, this);
+    this.input.keyboard.on('keydown-Q', () => this.inventory.next());
+  }
+
+  placeBlock(pointer) {
+    const x = Math.floor(pointer.worldX / this.blockSize);
+    const y = Math.floor(pointer.worldY / this.blockSize);
+    if (x >= 0 && x < this.gridWidth && y >= 0 && y < this.gridHeight) {
+      this.grid[y][x] = this.inventory.type;
+    }
+  }
+
+  drawGrid() {
+    this.graphics.clear();
+    for (let y = 0; y < this.gridHeight; y++) {
+      for (let x = 0; x < this.gridWidth; x++) {
+        const block = this.grid[y][x];
+        const colors = [0x8B4513, 0x00FF00, 0xAAAAAA];
+        if (block >= 0) {
+          this.graphics.fillStyle(colors[block], 1);
+          this.graphics.fillRect(x * this.blockSize, y * this.blockSize, this.blockSize, this.blockSize);
+        }
+        this.graphics.lineStyle(1, 0x333333, 0.5);
+        this.graphics.strokeRect(x * this.blockSize, y * this.blockSize, this.blockSize, this.blockSize);
+      }
+    }
+    const text = `Selected block: ${this.inventory.current}`;
+    if (!this.uiText) {
+      this.uiText = this.add.text(10, 10, text, { font: '16px Arial', fill: '#ffffff' });
+      this.uiText.setDepth(1);
+    } else {
+      this.uiText.setText(text);
+    }
+  }
+
+  update() {
+    this.drawGrid();
+  }
+}
+
+const config = {
+  type: Phaser.AUTO,
+  width: 640,
+  height: 480,
+  backgroundColor: '#000',
+  physics: {
+    default: 'arcade'
+  },
+  scene: [GameScene]
+};
+
+new Phaser.Game(config);


### PR DESCRIPTION
## Summary
- add index.html that loads Phaser and the main script
- implement basic block placement and inventory
- update README with usage instructions

## Testing
- `node -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841aa56c6ac83258d22b57ec4bd00e7