### PR TITLE
Add player movement, inventory modal and terrain

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,32 @@
   <style>
     body { margin: 0; padding: 0; }
     canvas { display: block; margin: 0 auto; }
+    #inventoryModal {
+      display: none;
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background: rgba(0, 0, 0, 0.8);
+      padding: 10px;
+      border: 1px solid #fff;
+    }
+    #inventoryModal .item {
+      width: 40px;
+      height: 40px;
+      margin: 5px;
+      display: inline-block;
+      cursor: pointer;
+    }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.js"></script>
 </head>
 <body>
+  <div id="inventoryModal">
+    <div class="item" data-type="0" style="background:#8B4513"></div>
+    <div class="item" data-type="1" style="background:#00FF00"></div>
+    <div class="item" data-type="2" style="background:#AAAAAA"></div>
+  </div>
   <script src="src/main.js"></script>
 </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,15 +1,66 @@
 class Inventory {
   constructor(scene) {
     this.scene = scene;
-    // simple inventory with 3 types of blocks
     this.blocks = [0, 1, 2];
     this.current = 0;
+    this.modal = document.getElementById('inventoryModal');
+    this.modal.querySelectorAll('.item').forEach(item => {
+      item.addEventListener('click', () => {
+        this.current = parseInt(item.dataset.type, 10);
+        this.hide();
+      });
+    });
+    this.hide();
   }
-  next() {
-    this.current = (this.current + 1) % this.blocks.length;
+  show() { this.modal.style.display = 'block'; }
+  hide() { this.modal.style.display = 'none'; }
+  toggle() { this.modal.style.display === 'none' ? this.show() : this.hide(); }
+  get type() { return this.blocks[this.current]; }
+}
+
+class Player {
+  constructor(scene, x, y) {
+    this.scene = scene;
+    this.blockSize = scene.blockSize;
+    this.x = x;
+    this.y = y;
+    this.vx = 0;
+    this.vy = 0;
+    this.onGround = false;
+    this.rect = scene.add.rectangle(x, y, this.blockSize, this.blockSize, 0xffff00);
   }
-  get type() {
-    return this.blocks[this.current];
+
+  update(cursors) {
+    const dt = this.scene.game.loop.delta / 1000;
+    const speed = 200;
+    if (cursors.left.isDown) {
+      this.vx = -speed;
+    } else if (cursors.right.isDown) {
+      this.vx = speed;
+    } else {
+      this.vx = 0;
+    }
+
+    if (cursors.up.isDown && this.onGround) {
+      this.vy = -400;
+      this.onGround = false;
+    }
+
+    this.vy += 800 * dt;
+    this.x += this.vx * dt;
+    this.y += this.vy * dt;
+
+    const tileX = Math.floor(this.x / this.blockSize);
+    const groundHeight = this.scene.getGroundHeight(tileX);
+    const groundY = (this.scene.gridHeight - groundHeight - 1) * this.blockSize;
+    if (this.y > groundY) {
+      this.y = groundY;
+      this.vy = 0;
+      this.onGround = true;
+    }
+
+    this.rect.x = this.x;
+    this.rect.y = this.y;
   }
 }
 
@@ -18,60 +69,73 @@ class GameScene extends Phaser.Scene {
     super('GameScene');
   }
 
-  preload() {
-    // placeholder colors for blocks
-  }
+  preload() {}
 
   create() {
-    this.inventory = new Inventory(this);
     this.blockSize = 32;
-    this.gridWidth = 20;
     this.gridHeight = 15;
-    this.grid = [];
-    for (let y = 0; y < this.gridHeight; y++) {
-      this.grid[y] = [];
-      for (let x = 0; x < this.gridWidth; x++) {
-        this.grid[y][x] = -1; // empty
-      }
-    }
+    this.inventory = new Inventory(this);
+    this.colors = [0x8B4513, 0x00FF00, 0xAAAAAA];
+    this.userBlocks = {};
+
+    this.player = new Player(this, 100, 100);
+    this.cameras.main.startFollow(this.player.rect, true, 0.1, 0.1);
+
+    this.cursors = this.input.keyboard.addKeys({
+      left: Phaser.Input.Keyboard.KeyCodes.A,
+      right: Phaser.Input.Keyboard.KeyCodes.D,
+      up: Phaser.Input.Keyboard.KeyCodes.SPACE,
+      inv: Phaser.Input.Keyboard.KeyCodes.I
+    });
+    this.cursors.inv.on('down', () => this.inventory.toggle());
+
     this.graphics = this.add.graphics();
     this.input.on('pointerdown', this.placeBlock, this);
-    this.input.keyboard.on('keydown-Q', () => this.inventory.next());
+  }
+
+  getGroundHeight(x) {
+    const base = 4;
+    return base + Math.floor((Math.sin(x / 5) + 1) * 2);
   }
 
   placeBlock(pointer) {
-    const x = Math.floor(pointer.worldX / this.blockSize);
-    const y = Math.floor(pointer.worldY / this.blockSize);
-    if (x >= 0 && x < this.gridWidth && y >= 0 && y < this.gridHeight) {
-      this.grid[y][x] = this.inventory.type;
-    }
+    if (this.inventory.modal.style.display !== 'none') return;
+    const tileX = Math.floor(pointer.worldX / this.blockSize);
+    const tileY = Math.floor(pointer.worldY / this.blockSize);
+    const key = `${tileX},${tileY}`;
+    this.userBlocks[key] = this.inventory.type;
   }
 
-  drawGrid() {
+  drawWorld() {
+    const startX = Math.floor(this.cameras.main.scrollX / this.blockSize) - 1;
+    const endX = startX + Math.ceil(this.cameras.main.width / this.blockSize) + 2;
     this.graphics.clear();
-    for (let y = 0; y < this.gridHeight; y++) {
-      for (let x = 0; x < this.gridWidth; x++) {
-        const block = this.grid[y][x];
-        const colors = [0x8B4513, 0x00FF00, 0xAAAAAA];
-        if (block >= 0) {
-          this.graphics.fillStyle(colors[block], 1);
+    for (let x = startX; x < endX; x++) {
+      const ground = this.getGroundHeight(x);
+      for (let y = 0; y < this.gridHeight; y++) {
+        const key = `${x},${y}`;
+        let block = this.userBlocks[key];
+        if (block === undefined && y >= this.gridHeight - ground) {
+          block = 0;
+        }
+        if (block !== undefined) {
+          this.graphics.fillStyle(this.colors[block], 1);
           this.graphics.fillRect(x * this.blockSize, y * this.blockSize, this.blockSize, this.blockSize);
         }
-        this.graphics.lineStyle(1, 0x333333, 0.5);
+        this.graphics.lineStyle(1, 0x333333, 0.3);
         this.graphics.strokeRect(x * this.blockSize, y * this.blockSize, this.blockSize, this.blockSize);
       }
     }
-    const text = `Selected block: ${this.inventory.current}`;
     if (!this.uiText) {
-      this.uiText = this.add.text(10, 10, text, { font: '16px Arial', fill: '#ffffff' });
-      this.uiText.setDepth(1);
-    } else {
-      this.uiText.setText(text);
+      this.uiText = this.add.text(10, 10, '', { font: '16px Arial', fill: '#ffffff' });
+      this.uiText.setScrollFactor(0);
     }
+    this.uiText.setText(`Bloco selecionado: ${this.inventory.current}`);
   }
 
   update() {
-    this.drawGrid();
+    this.player.update(this.cursors);
+    this.drawWorld();
   }
 }
 
@@ -80,9 +144,7 @@ const config = {
   width: 640,
   height: 480,
   backgroundColor: '#000',
-  physics: {
-    default: 'arcade'
-  },
+  physics: { default: 'arcade' },
   scene: [GameScene]
 };
 


### PR DESCRIPTION
## Summary
- create inventory modal markup and CSS
- add player with WASD controls and jumping
- allow opening inventory with I key and selecting block with mouse
- generate simple infinite terrain with basic height function

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841ac2a02bc832589e460e6641fac6c