### PR TITLE
Add inventory and player-block collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Simple Phaser Terraria-like Game
 
-This is a minimal example of a game built with [Phaser 3](https://phaser.io/). It demonstrates a very basic terrain-building mechanic with a simple inventory.
+This is a minimal example of a game built with [Phaser 3](https://phaser.io/). It demonstrates a basic terrain-building mechanic with a simple inventory system that tracks block quantities.
 
 ## Features
 
-- Click to place blocks on a grid.
-- Press **Q** to cycle through block types.
-- Inventory shows the selected block.
+- Left click to place blocks on a grid.
+- Right click to remove blocks and return them to your inventory.
+- Press **I** to open the inventory and choose the block type.
+- Inventory displays how many blocks of each type you have left.
+- The player now collides with blocks you place.
 
 ## Setup
 

--- a/index.html
+++ b/index.html
@@ -22,15 +22,32 @@
       margin: 5px;
       display: inline-block;
       cursor: pointer;
+      position: relative;
+      color: #fff;
+      font-family: Arial, sans-serif;
+      line-height: 40px;
+      text-align: center;
+    }
+    #inventoryModal .count {
+      position: absolute;
+      bottom: 2px;
+      right: 4px;
+      font-size: 12px;
     }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.js"></script>
 </head>
 <body>
   <div id="inventoryModal">
-    <div class="item" data-type="0" style="background:#8B4513"></div>
-    <div class="item" data-type="1" style="background:#00FF00"></div>
-    <div class="item" data-type="2" style="background:#AAAAAA"></div>
+    <div class="item" data-type="0" style="background:#8B4513">
+      <span class="count" data-type="0"></span>
+    </div>
+    <div class="item" data-type="1" style="background:#00FF00">
+      <span class="count" data-type="1"></span>
+    </div>
+    <div class="item" data-type="2" style="background:#AAAAAA">
+      <span class="count" data-type="2"></span>
+    </div>
   </div>
   <script src="src/main.js"></script>
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ class Inventory {
   constructor(scene) {
     this.scene = scene;
     this.blocks = [0, 1, 2];
+    this.counts = [10, 10, 10];
     this.current = 0;
     this.modal = document.getElementById('inventoryModal');
     this.modal.querySelectorAll('.item').forEach(item => {
@@ -10,12 +11,32 @@ class Inventory {
         this.hide();
       });
     });
+    this.updateUI();
     this.hide();
   }
-  show() { this.modal.style.display = 'block'; }
+  show() {
+    this.updateUI();
+    this.modal.style.display = 'block';
+  }
   hide() { this.modal.style.display = 'none'; }
   toggle() { this.modal.style.display === 'none' ? this.show() : this.hide(); }
   get type() { return this.blocks[this.current]; }
+
+  updateUI() {
+    this.modal.querySelectorAll('.count').forEach(span => {
+      const type = parseInt(span.dataset.type, 10);
+      span.textContent = this.counts[type];
+    });
+  }
+
+  useCurrent() {
+    if (this.counts[this.current] > 0) {
+      this.counts[this.current]--;
+      this.updateUI();
+      return true;
+    }
+    return false;
+  }
 }
 
 class Player {
@@ -51,8 +72,13 @@ class Player {
     this.y += this.vy * dt;
 
     const tileX = Math.floor(this.x / this.blockSize);
-    const groundHeight = this.scene.getGroundHeight(tileX);
-    const groundY = (this.scene.gridHeight - groundHeight - 1) * this.blockSize;
+    const bottomTile = Math.floor((this.y + this.blockSize / 2) / this.blockSize);
+
+    let groundY = (this.scene.gridHeight - this.scene.getGroundHeight(tileX) - 1) * this.blockSize;
+    if (this.scene.getBlock(tileX, bottomTile) !== undefined) {
+      groundY = Math.min(groundY, bottomTile * this.blockSize - this.blockSize / 2);
+    }
+
     if (this.y > groundY) {
       this.y = groundY;
       this.vy = 0;
@@ -98,12 +124,35 @@ class GameScene extends Phaser.Scene {
     return base + Math.floor((Math.sin(x / 5) + 1) * 2);
   }
 
+  getBlock(x, y) {
+    const key = `${x},${y}`;
+    if (this.userBlocks[key] !== undefined) {
+      return this.userBlocks[key];
+    }
+    const ground = this.getGroundHeight(x);
+    if (y >= this.gridHeight - ground) {
+      return 0;
+    }
+    return undefined;
+  }
+
   placeBlock(pointer) {
     if (this.inventory.modal.style.display !== 'none') return;
     const tileX = Math.floor(pointer.worldX / this.blockSize);
     const tileY = Math.floor(pointer.worldY / this.blockSize);
     const key = `${tileX},${tileY}`;
-    this.userBlocks[key] = this.inventory.type;
+    if (pointer.rightButtonDown()) {
+      if (this.userBlocks[key] !== undefined) {
+        const type = this.userBlocks[key];
+        delete this.userBlocks[key];
+        this.inventory.counts[type]++;
+        this.inventory.updateUI();
+      }
+    } else {
+      if (this.inventory.useCurrent()) {
+        this.userBlocks[key] = this.inventory.type;
+      }
+    }
   }
 
   drawWorld() {
@@ -130,7 +179,8 @@ class GameScene extends Phaser.Scene {
       this.uiText = this.add.text(10, 10, '', { font: '16px Arial', fill: '#ffffff' });
       this.uiText.setScrollFactor(0);
     }
-    this.uiText.setText(`Bloco selecionado: ${this.inventory.current}`);
+    const count = this.inventory.counts[this.inventory.current];
+    this.uiText.setText(`Bloco selecionado: ${this.inventory.current} (x${count})`);
   }
 
   update() {


### PR DESCRIPTION
## Summary
- implement inventory with block counts
- allow placing and removing blocks using the inventory
- update UI to show item counts
- make player collide with newly placed blocks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841ad67a34c83259618e26d4e9db2cf